### PR TITLE
Grammer and typos fixed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 # Changelog
 
-## v0.2.0 (2022-2-8)
- - Down Elixir Support version to 1.10
- - add :except, only to option whtn `use`
+## v0.2.0 (2022-02-08)
+
+ - Downgraded Elixir Support version to `1.10`
+ - added `:except`, only to option with `use`
+
 ## v0.1.0 (2022-2-8)
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # AttrReader
 
-In Elixir, Module variable is often used as a constant.
+In Elixir, module variables are often used as a constant.
 But I didn't want to bother to define a getter when I wanted to refer to it with Test code etc.
 If you use AttrReader, you can use it without having to define the getter of the module attribute.
 
@@ -25,7 +25,7 @@ end
 
 ## Usage
 
-### Defines by `use`
+### Defined by `use`
 
 ```elixir
 iex> defmodule UseAttrReader do
@@ -41,7 +41,7 @@ iex> UseAttrReader.bar()
 :bar
 ```
 
-**with except**
+> **with except**
 
 ```elixir
 iex> defmodule UseAttrReader do
@@ -57,7 +57,7 @@ iex> UseAttrReader.foo()
 ** (UndefinedFunctionError)
 ```
 
-**with only**
+> **with only**
 
 ```elixir
 iex> defmodule UseAttrReader do
@@ -73,7 +73,7 @@ iex> UseAttrReader.bar()
 ** (UndefinedFunctionError)
 ```
 
-### Defines by `macro`
+### Defined by `macro`
 
 ```elixir
 iex> defmodule UseAttrReaderMacro do

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # AttrReader
 
-In Elixir, module variables are often used as a constant.
+In Elixir, the module variable is often used as a constant.
 But I didn't want to bother to define a getter when I wanted to refer to it with Test code etc.
 If you use AttrReader, you can use it without having to define the getter of the module attribute.
 


### PR DESCRIPTION
Some sentences and examples were hard to understand.
```diff
- Down Elixir Support version to 1.10
+ Downgraded Elixir Support version to `1.10`

- In Elixir, Module variable is often used as a constant.
+ In Elixir, the module variable is often used as a constant.